### PR TITLE
Init Args & Examples

### DIFF
--- a/.github/workflows/basic-example.yml
+++ b/.github/workflows/basic-example.yml
@@ -20,7 +20,7 @@ jobs:
         uses: opentofu/setup-opentofu@v1
 
       - name: Plan and Apply
-        uses: jlroskens/tofu-plan-approve-apply
+        uses: jlroskens/tofu-plan-approve-apply@${{ github.head_ref }}
         with:
           require-approval: true
           required-approvers: jlroskens

--- a/.github/workflows/basic-example.yml
+++ b/.github/workflows/basic-example.yml
@@ -1,0 +1,28 @@
+name: Basic Example w/ Approval
+
+on:
+  push:
+    branches:
+      - main
+      - feature/init-var-args
+    
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+jobs:
+  plan-apply:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+
+      - name: Plan and Apply
+        uses: jlroskens/tofu-plan-approve-apply
+        with:
+          require-approval: true
+          required-approvers: jlroskens
+          working-directory: examples/basic
+         

--- a/.github/workflows/basic-example.yml
+++ b/.github/workflows/basic-example.yml
@@ -20,7 +20,7 @@ jobs:
         uses: opentofu/setup-opentofu@v1
 
       - name: Plan and Apply
-        uses: jlroskens/tofu-plan-approve-apply@${{ github.head_ref }}
+        uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
         with:
           require-approval: true
           required-approvers: jlroskens

--- a/.github/workflows/example-basic-approval.yml
+++ b/.github/workflows/example-basic-approval.yml
@@ -25,4 +25,8 @@ jobs:
           require-approval: true
           required-approvers: jlroskens
           working-directory: examples/basic
+      - name: Outputs
+        shell: bash
+        run: |
+          echo "Random Number: $(tofu output -raw random_value)"
          

--- a/.github/workflows/example-basic-approval.yml
+++ b/.github/workflows/example-basic-approval.yml
@@ -1,4 +1,4 @@
-name: 🟨 Variables Example
+name: 🟨 Basic Example w/ Approval
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
   issues: write
 jobs:
   plan-apply:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install OpenTofu
@@ -22,9 +22,7 @@ jobs:
       - name: Plan and Apply
         uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
         with:
-          working-directory: examples/variables
-          var-files: |-
-            example.tfvars
-          vars: |-
-             state_file_name=variables_example.tfstate
-          init-vars-enabled: true
+          require-approval: true
+          required-approvers: jlroskens
+          working-directory: examples/basic
+         

--- a/.github/workflows/example-basic-approval.yml
+++ b/.github/workflows/example-basic-approval.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/init-var-args
     
   workflow_dispatch:
 
@@ -20,7 +19,7 @@ jobs:
         uses: opentofu/setup-opentofu@v1
 
       - name: Plan and Apply
-        uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
+        uses: jlroskens/tofu-plan-approve-apply@v1
         with:
           require-approval: true
           required-approvers: jlroskens

--- a/.github/workflows/example-basic-approval.yml
+++ b/.github/workflows/example-basic-approval.yml
@@ -12,6 +12,7 @@ permissions:
   issues: write
 jobs:
   plan-apply:
+    name: Plan -> Approve -> Apply
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -1,4 +1,4 @@
-name: Basic Example w/ Approval
+name: 🟨 Basic Example
 
 on:
   push:
@@ -22,7 +22,5 @@ jobs:
       - name: Plan and Apply
         uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
         with:
-          require-approval: true
-          required-approvers: jlroskens
           working-directory: examples/basic
          

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/init-var-args
     
   workflow_dispatch:
 
@@ -20,7 +19,7 @@ jobs:
         uses: opentofu/setup-opentofu@v1
 
       - name: Plan and Apply
-        uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
+        uses: jlroskens/tofu-plan-approve-apply@v1
         with:
           working-directory: examples/basic
       - name: Outputs

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -23,4 +23,8 @@ jobs:
         uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
         with:
           working-directory: examples/basic
+      - name: Outputs
+        shell: bash
+        run: |
+          echo "Random Number: $(tofu output -raw random_value)"
          

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -13,7 +13,7 @@ permissions:
   issues: write
 jobs:
   plan-apply:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install OpenTofu

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -45,4 +45,4 @@ jobs:
           echo "## Job Outputs" >> $GITHUB_STEP_SUMMARY
           echo "**Random Number:** $(tofu output -raw ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }} random_value)" >> $GITHUB_STEP_SUMMARY
           echo "**.terraform directory contents:**"  >> $GITHUB_STEP_SUMMARY
-          echo -e "```\n$(ls -l .terraform)\n```"  >> $GITHUB_STEP_SUMMARY
+          echo -e '```'"\n$(ls -l .terraform)\n"'```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -20,7 +20,7 @@ jobs:
         uses: opentofu/setup-opentofu@v1
 
       - name: Plan and Apply
-        uses: jlroskens/tofu-plan-approve-apply
+        uses: jlroskens/tofu-plan-approve-apply@${{ github.head_ref }}
         with:
           require-approval: true
           required-approvers: jlroskens

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -44,5 +44,7 @@ jobs:
           echo ".terraform directory contents:" 
           echo "## Job Outputs" >> $GITHUB_STEP_SUMMARY
           echo "**Random Number:** $(tofu output -raw ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }} random_value)" >> $GITHUB_STEP_SUMMARY
-          echo "**.terraform directory contents:**"  >> $GITHUB_STEP_SUMMARY
+          echo "### .terraform directory contents:"  >> $GITHUB_STEP_SUMMARY
           echo -e '```'"\n$(ls -l .terraform)\n"'```' >> $GITHUB_STEP_SUMMARY
+          echo "### .terraform/variables_example.tfstate contents:"  >> $GITHUB_STEP_SUMMARY
+          echo -e '```'"\n$(cat .terraform/variables_example.tfstate)\n"'```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -26,5 +26,11 @@ jobs:
           var-files: |-
             example.tfvars
           vars: |-
-             state_file_name=variables_example.tfstate
+             state_file_path=.terraform/variables_example.tfstate
           init-vars-enabled: true
+      - name: Outputs
+        shell: bash
+        run: |
+          echo "Random Number: $(tofu output -raw random_value)"
+          echo "State File:" 
+          ls -l .terraform/variables_example.tfstate

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Plan and Apply
         uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
+        id: plan-apply
         with:
           working-directory: examples/variables
           var-files: |-
@@ -39,6 +40,6 @@ jobs:
       
       - name: Outputs
         run: |
-          echo "Random Number: $(tofu output -raw random_value)"
-          echo "State File:" 
+          echo "Random Number: $(tofu output -raw random_value ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }})"
+          echo ".terraform directory contents:" 
           ls -l .terraform

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -40,6 +40,6 @@ jobs:
       
       - name: Outputs
         run: |
-          echo "Random Number: $(tofu output -raw random_value ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }})"
+          echo "Random Number: $(tofu output -raw ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }} random_value)"
           echo ".terraform directory contents:" 
           ls -l .terraform

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/init-var-args
     
   workflow_dispatch:
 
@@ -29,7 +28,7 @@ jobs:
         run: mkdir -p .terraform
 
       - name: Plan and Apply
-        uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
+        uses: jlroskens/tofu-plan-approve-apply@v1
         id: plan-apply
         with:
           working-directory: examples/variables

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -44,7 +44,5 @@ jobs:
           echo ".terraform directory contents:" 
           echo "## Job Outputs" >> $GITHUB_STEP_SUMMARY
           echo "**Random Number:** $(tofu output -raw ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }} random_value)" >> $GITHUB_STEP_SUMMARY
-          echo "### .terraform directory contents:"  >> $GITHUB_STEP_SUMMARY
-          echo -e '```'"\n$(ls -l .terraform)\n"'```' >> $GITHUB_STEP_SUMMARY
           echo "### .terraform/variables_example.tfstate contents:"  >> $GITHUB_STEP_SUMMARY
-          echo -e '```'"\n$(cat .terraform/variables_example.tfstate)\n"'```' >> $GITHUB_STEP_SUMMARY
+          echo -e '```'"\n$(jq '.' .terraform/variables_example.tfstate)\n"'```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
   issues: write
+defaults:
+    run:
+      shell: bash
+      working-directory: examples/variables
 jobs:
   plan-apply:
     runs-on: ubuntu-latest
@@ -21,7 +25,6 @@ jobs:
         uses: opentofu/setup-opentofu@v1
       
       - name: Create .terraform Directory
-        shell: bash
         run: mkdir -p .terraform
 
       - name: Plan and Apply
@@ -35,8 +38,7 @@ jobs:
           init-vars-enabled: true
       
       - name: Outputs
-        shell: bash
         run: |
           echo "Random Number: $(tofu output -raw random_value)"
           echo "State File:" 
-          ls -l .terraform/variables_example.tfstate
+          ls -l .terraform

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -13,7 +13,7 @@ permissions:
   issues: write
 jobs:
   plan-apply:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install OpenTofu

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -16,8 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v1
+      
+      - name: Create .terraform Directory
+        shell: bash
+        run: mkdir -p .terraform
 
       - name: Plan and Apply
         uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
@@ -28,6 +33,7 @@ jobs:
           vars: |-
              state_file_path=.terraform/variables_example.tfstate
           init-vars-enabled: true
+      
       - name: Outputs
         shell: bash
         run: |

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -1,0 +1,33 @@
+name: Basic Example w/ Approval
+
+on:
+  push:
+    branches:
+      - main
+      - feature/init-var-args
+    
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+jobs:
+  plan-apply:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+
+      - name: Plan and Apply
+        uses: jlroskens/tofu-plan-approve-apply
+        with:
+          require-approval: true
+          required-approvers: jlroskens
+          working-directory: examples/variables
+          var-files: |-
+            example.tfvars
+          vars: |-
+             state_file_name=variables_example.tfstate
+          init-vars-enabled: true
+         

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -17,6 +17,7 @@ defaults:
       working-directory: examples/variables
 jobs:
   plan-apply:
+    name: Var Args + Plan -> Approve
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -42,4 +42,7 @@ jobs:
         run: |
           echo "Random Number: $(tofu output -raw ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }} random_value)"
           echo ".terraform directory contents:" 
-          ls -l .terraform
+          echo "## Job Outputs" >> $GITHUB_STEP_SUMMARY
+          echo "**Random Number:** $(tofu output -raw ${{ steps.plan-apply.outputs.var-file-args }} ${{ steps.plan-apply.outputs.var-args }} random_value)" >> $GITHUB_STEP_SUMMARY
+          echo "**.terraform directory contents:**"  >> $GITHUB_STEP_SUMMARY
+          echo -e "```\n$(ls -l .terraform)\n```"  >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/variables-example.yml
+++ b/.github/workflows/variables-example.yml
@@ -20,7 +20,7 @@ jobs:
         uses: opentofu/setup-opentofu@v1
 
       - name: Plan and Apply
-        uses: jlroskens/tofu-plan-approve-apply@${{ github.head_ref }}
+        uses: jlroskens/tofu-plan-approve-apply@feature/init-var-args
         with:
           require-approval: true
           required-approvers: jlroskens

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Enabling the `require-approval` requires an issue comment to be approved prior t
 ```
 
 ### Kitchen Sink
-Enabling the `require-approval` requires an issue comment to be approved prior to the `tofu apply` being executed. For details on this process, see the [trstringer/manual-approval action](https://github.com/trstringer/manual-approval) action that this composite action utilizes.
+Executes `tofu init`, `plan` and `apply` with `-var-file` and `-var` arguments. Enables arguments for `tofu init`. Requires issue approval between `plan` and `apply` and sets the `working-directory`.
 
 ```
       - name: Plan, Approve, Apply
@@ -55,6 +55,7 @@ Enabling the `require-approval` requires an issue comment to be approved prior t
           vars: |-
             my_string_var=my_value
             my_map_var={ "my_key": "my_value" }
+          init-vars-enabled: true
           require-approval: true
           required-approvers: githubuser1, githubuser2
           working-directory: {path_to_manifest}

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,11 @@ name: 'Tofu Plan & Apply'
 description: >
   Runs tofu init, validate, plan and apply. If approvals are configured, create's an issue with the plan output
   and waits for an approval before executing the apply.
+
+branding:
+  icon: 'box'
+  color: 'yellow'
+
 inputs:
   var-files:
     type: string
@@ -46,9 +51,13 @@ inputs:
     required: false
     default: '.'
 
-branding:
-  icon: 'box'
-  color: 'yellow'
+outputs:
+  var-file-args:
+    description: "Command line `-var-file {filename}` argument(s) that were used to execute tofu apply and plan steps (and init if configured)."
+    value: ${{ steps.parse-inputs.outputs.tfvar-files }}
+  var-args:
+    description: "Command line `-var {var_name}={value}` argument(s) that were used to execute tofu apply and plan steps (and init if configured)."
+    value: ${{ steps.parse-inputs.outputs.tfvars }}
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,11 @@ runs:
       shell: bash
       run: |
         $GITHUB_ACTION_PATH/print_step.sh 3
-        tofu validate -no-color
+        if [[ $INIT_VARS_ENABLED ]]; then
+          tofu validate -no-color ${{ steps.parse-inputs.outputs.tfvar-files }} ${{ steps.parse-inputs.outputs.tfvars }}
+        else
+          tofu validate -no-color
+        fi
 
     - name: 🟨 Tofu Plan
       id: plan

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
       commented on to allow the action to continue. For more details, see the trstringer/manual-approval@v1 action'
       documentation.
     required: false
-    default: true
+    default: false
   required-approvers:
     type: string
     description: Comma separated list of users who can approve a plan. Required if `require-approval` is true.

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
 
     - name: ⌛ Wait for Issue Approval
       uses: trstringer/manual-approval@v1
-      if: ${{ inputs.require-approval && steps.plan.outputs.exitcode == 2 }}
+      if: ${{ inputs.require-approval == 'true' && steps.plan.outputs.exitcode == '2' }}
       with:
         secret: ${{ github.TOKEN }}
         approvers: ${{ steps.parse-inputs.outputs.required-approvers }}

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
 
     - name: ⌛ Wait for Issue Approval
       uses: trstringer/manual-approval@v1
-      if: steps.plan.outputs.exitcode == 2 && inputs.require-approval
+      if: ${{ inputs.require-approval && steps.plan.outputs.exitcode == 2 }}
       with:
         secret: ${{ github.TOKEN }}
         approvers: ${{ steps.parse-inputs.outputs.required-approvers }}

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
         myvar02 3
       ```
     required: false
+  init-vars-enabled:
+    type: bool
+    description: When enabled, passes [var-files] and [vars] inputs as command line arguments to the tofu init step.
+    default: false
   require-approval:
     type: bool
     description: >
@@ -54,26 +58,35 @@ runs:
       env:
         TF_VAR_FILES: ${{ inputs.var-files }}
         TF_VARS: ${{ inputs.vars }}
+        INIT_VARS_ENABLED: ${{ inputs.init-vars-enabled }}
         REQUIRE_APPROVAL: ${{ inputs.require-approval }}
         APPROVERS: ${{ inputs.required-approvers }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
       shell: bash
-      run: $GITHUB_ACTION_PATH/parse_inputs.sh
+      run: | 
+        $GITHUB_ACTION_PATH/print_step.sh 1
+        $GITHUB_ACTION_PATH/parse_inputs.sh
       
     - name: 🟨 Tofu Init
       id: init
       working-directory: ${{ steps.parse-inputs.outputs.working-directory }}
       shell: bash
+      env:
+        INIT_VARS_ENABLED: ${{ steps.parse-inputs.outputs.init-vars-enabled }}
       run: |
-        echo "🟨 Tofu Init"
-        tofu init -input=false
+        $GITHUB_ACTION_PATH/print_step.sh 2
+        if [[ $INIT_VARS_ENABLED ]]; then
+          tofu init -input=false ${{ steps.parse-inputs.outputs.tfvar-files }} ${{ steps.parse-inputs.outputs.tfvars }}
+        else
+          tofu init -input=false
+        fi
 
     - name: 🟨 Tofu Validate
       id: validate
       working-directory: ${{ steps.parse-inputs.outputs.working-directory }}
       shell: bash
-      run: | 
-        echo "🟨 Tofu Validate"
+      run: |
+        $GITHUB_ACTION_PATH/print_step.sh 3
         tofu validate -no-color
 
     - name: 🟨 Tofu Plan
@@ -81,7 +94,7 @@ runs:
       working-directory: ${{ steps.parse-inputs.outputs.working-directory }}
       shell: bash
       run: |
-        echo "🟨 Tofu Plan"
+        $GITHUB_ACTION_PATH/print_step.sh 4
         tofu plan -input=false -compact-warnings -no-color -detailed-exitcode ${{ steps.parse-inputs.outputs.tfvar-files }} ${{ steps.parse-inputs.outputs.tfvars }} -out .tofuplan
 
     - name: ⌛ Wait for Issue Approval
@@ -105,7 +118,7 @@ runs:
       working-directory: ${{ steps.parse-inputs.outputs.working-directory }}
       shell: bash
       run: |
-        echo "🟨 Tofu Apply"
+        $GITHUB_ACTION_PATH/print_step.sh 6
         tofu apply -compact-warnings -no-color .tofuplan
     
     - name: 🧾Job Summary
@@ -117,7 +130,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        echo "🧾Job Summary"
+        $GITHUB_ACTION_PATH/print_step.sh 7
         echo "## Apply Result" >> $GITHUB_STEP_SUMMARY
         echo -e '```'"\n$APPLY_OUTPUT\n"'```' >> $GITHUB_STEP_SUMMARY
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,36 @@
+# Simple Random Number Terraform Example
+
+This example demonstrates how to use Terraform to generate a random number and output it.
+
+## Files
+
+- `main.tf` - The main Terraform configuration file
+
+## What it does
+
+1. Uses the `random` provider from HashiCorp
+2. Creates a random integer between 1 and 100
+3. Outputs the generated random number
+
+## How to use
+
+1. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+
+2. Apply the configuration:
+   ```bash
+   terraform apply
+   ```
+
+3. The random number will be displayed in the output under `random_number`
+
+## Example Output
+
+```
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+random_number = 42

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+resource "random_integer" "example" {
+  min = 1
+  max = 100
+}
+
+output "random_number" {
+  description = "A random number between 1 and 100"
+  value       = random_integer.example.result
+}

--- a/examples/variables/README.md
+++ b/examples/variables/README.md
@@ -18,17 +18,17 @@ This example demonstrates how to use variables in OpenTofu to configure a random
 
 1. Initialize OpenTofu (provide the state file name):
    ```bash
-   tofu init -var="state_file_name=terraform.tfstate"
+   tofu init -var="state_file_path=.terraform/terraform.tfstate"
    ```
 
 2. Plan the configuration:
    ```bash
-   tofu plan -var="state_file_name=terraform.tfstate"
+   tofu plan -var="state_file_path=.terraform/terraform.tfstate"
    ```
 
 3. Apply the configuration:
    ```bash
-   tofu apply -var="state_file_name=terraform.tfstate"
+   tofu apply -var="state_file_path=.terraform/terraform.tfstate"
    ```
 
 ## Output

--- a/examples/variables/README.md
+++ b/examples/variables/README.md
@@ -1,0 +1,36 @@
+# OpenTofu Variables Example
+
+This example demonstrates how to use variables in OpenTofu to configure a random integer resource and local backend state file.
+
+## Files
+
+- `variables.tf` - Defines the input variables
+- `terraform.tfvars` - Sets values for the min and max variables
+- `main.tf` - Contains the main configuration with resources and outputs
+
+## Variables
+
+- `state_file_name` (string) - Name of the local state file (must be provided when running)
+- `min_value` (number) - Minimum value for the random integer (default: 1)
+- `max_value` (number) - Maximum value for the random integer (default: 100)
+
+## Usage
+
+1. Initialize OpenTofu (provide the state file name):
+   ```bash
+   tofu init -var="state_file_name=terraform.tfstate"
+   ```
+
+2. Plan the configuration:
+   ```bash
+   tofu plan -var="state_file_name=terraform.tfstate"
+   ```
+
+3. Apply the configuration:
+   ```bash
+   tofu apply -var="state_file_name=terraform.tfstate"
+   ```
+
+## Output
+
+The configuration will output a random integer between the min and max values defined in the variables.

--- a/examples/variables/example.tfvars
+++ b/examples/variables/example.tfvars
@@ -1,0 +1,2 @@
+min_value = 1
+max_value = 100

--- a/examples/variables/main.tf
+++ b/examples/variables/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "local" {
-    path = var.state_file_name
+    path = var.state_file_path
   }
 }
 

--- a/examples/variables/main.tf
+++ b/examples/variables/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "local" {
+    path = var.state_file_name
+  }
+}
+
+resource "random_integer" "example" {
+  min = var.min_value
+  max = var.max_value
+}
+
+output "random_value" {
+  value = random_integer.example.result
+}

--- a/examples/variables/variables.tf
+++ b/examples/variables/variables.tf
@@ -1,0 +1,14 @@
+variable "state_file_name" {
+  description = "Name of the local state file"
+  type        = string
+}
+
+variable "min_value" {
+  description = "Minimum value for the random integer"
+  type        = number
+}
+
+variable "max_value" {
+  description = "Maximum value for the random integer"
+  type        = number
+}

--- a/examples/variables/variables.tf
+++ b/examples/variables/variables.tf
@@ -1,5 +1,5 @@
-variable "state_file_name" {
-  description = "Name of the local state file"
+variable "state_file_path" {
+  description = "Path to the local state file"
   type        = string
 }
 

--- a/parse_inputs.sh
+++ b/parse_inputs.sh
@@ -29,6 +29,11 @@ assert_inputs_are_valid() {
         fi
     fi
 
+    if [[ "${INIT_VARS_ENABLED^^}" != 'TRUE' ]] && [[ "${INIT_VARS_ENABLED^^}" != 'FALSE' ]]; then
+        echo "Invalid value \"${INIT_VARS_ENABLED}\" set for `init-vars-enabled`. Valid values are true or false."
+        exit 1
+    fi
+
     if [[ -n ${WORKING_DIRECTORY+x} ]]; then
         if [[ ! -d "$WORKING_DIRECTORY" ]]; then
             echo "Working Directory '$WORKING_DIRECTORY' not found. Input \`working-directory\` must be set to a valid directory."
@@ -78,6 +83,12 @@ assign_outputs() {
             _var_values+=("-var $_var_value")
         done <<< "$TF_VARS"
         output_value 'tfvars' "${_var_values[@]}"
+    fi
+
+    if [[ -z ${INIT_VARS_ENABLED+x} ]]; then
+        output_value 'init-vars-enabled' '.'
+    else
+        output_value 'init-vars-enabled' "$INIT_VARS_ENABLED"
     fi
 
     if [[ -z ${REQUIRE_APPROVAL+x} ]]; then

--- a/print_step.sh
+++ b/print_step.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+set -e
+
+if [[ -z "$1" ]]; then
+    echo "ERROR: Step number argument is required." >&2
+    echo "         usage: ./print_step.sh {step_number}" >&2
+    exit 1
+fi
+
+step_number=$1
+
+case $step_number in
+    1)
+        echo "🔬 Validate and Parse Inputs"
+        ;;
+    2)
+        echo "🟨 Tofu Init"
+        ;;
+    3)
+        echo "🟨 Tofu Validate"
+        ;;
+    4)
+        echo "🟨 Tofu Plan"
+        ;;
+    6)
+        echo "🟨 Tofu Apply"
+        ;;
+    7)
+        echo "🧾Job Summary"
+        ;;
+    *)
+        echo "WARN: Unknown step number $$step_number. Valid values: [1, 2, 3, 4, 6, 7]."
+        ;;
+esac


### PR DESCRIPTION
- Added new `init-vars-enabled` input to enable passing of `-var` and `-var-file` arguments to `tofu init` and `tofu validate` steps.
- New `var-file-args` and `var-args` that output the command line arguments that were passed to terraform commands for variable files and variables.
- Added example workflows demonstrating usage of this action.